### PR TITLE
fix: assigneeの自動付与実装

### DIFF
--- a/.github/workflows/assign-author.yaml
+++ b/.github/workflows/assign-author.yaml
@@ -1,0 +1,15 @@
+name: Assign Author
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+jobs:
+  assign-author:
+    if: ${{ ! contains(fromJson('["renovate[bot]", "dependabot[bot]"]'), github.actor) }}
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: technote-space/assign-author@v1


### PR DESCRIPTION
## やったこと
- github actionのassigneesの自動設定のファイル追加

## やっていないこと
- 

## 動作確認
- 

## 参考
- 